### PR TITLE
ファイル詳細表示内のページ遷移履歴の削除

### DIFF
--- a/web/src/components/FilePage.tsx
+++ b/web/src/components/FilePage.tsx
@@ -9,7 +9,7 @@ import {
   type RenameRecord,
 } from '../lib/api'
 import { formatDate, formatBytes } from '../lib/format'
-import { navigate } from '../lib/router'
+import { navigate, replaceUrl } from '../lib/router'
 import DiffView from './DiffView'
 
 interface FilePageProps {
@@ -107,22 +107,22 @@ export default function FilePage({ fileId, fromId, toId }: FilePageProps) {
 
   function handleRowClick(snapId: string) {
     // Default: show diff with previous (auto-resolve from)
-    navigate(`/files/${fileId}/diff/${snapId}`)
+    replaceUrl(`/files/${fileId}/diff/${snapId}`)
   }
 
   function handleSetFrom(e: React.MouseEvent, snapId: string) {
     e.stopPropagation()
     if (toId) {
-      navigate(`/files/${fileId}/diff/${snapId}/${toId}`)
+      replaceUrl(`/files/${fileId}/diff/${snapId}/${toId}`)
     }
   }
 
   function handleSetTo(e: React.MouseEvent, snapId: string) {
     e.stopPropagation()
     if (resolvedFromId) {
-      navigate(`/files/${fileId}/diff/${resolvedFromId}/${snapId}`)
+      replaceUrl(`/files/${fileId}/diff/${resolvedFromId}/${snapId}`)
     } else {
-      navigate(`/files/${fileId}/diff/${snapId}`)
+      replaceUrl(`/files/${fileId}/diff/${snapId}`)
     }
   }
 


### PR DESCRIPTION
## Summary

私が依頼結果
ファイル詳細表示内で、スナップショット選ぶとその選択が全て履歴になっているので、
ファイル詳細表示で戻るを押すと一覧に戻ってほしいです。


## Execution Report

Piece `expert` completed successfully.

Closes #9